### PR TITLE
Created a Hook to handle modal routing

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,6 +3,7 @@
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import Dashboard from "@/components/dashboard/Dashboard";
 import { useStore } from "@/store/useStore";
+import { useHashModalRouting } from "@/utils/useHashModalRouting";
 import { Button } from "@heroui/react";
 import { Icon } from "@iconify/react/dist/iconify.js";
 import Image from "next/image";
@@ -72,6 +73,9 @@ function LandingPage() {
 // Component that handles OAuth errors from URL
 function HomeContent() {
   const searchParams = useSearchParams();
+
+  // Use custom hook for hash-based modal routing
+  useHashModalRouting();
 
   // Handle OAuth errors from URL (token is now in HttpOnly cookie)
   useEffect(() => {

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -59,21 +59,21 @@ export default function Footer() {
           <Link
             onClick={() => setIsSupportOpen(true)}
             className="hover:underline hover:underline-offset-4"
-            href="#"
+            href="#support"
           >
             Support
           </Link>
           <Link
             onClick={() => setIsPrivacyPolicyOpen(true)}
             className="hover:underline hover:underline-offset-4"
-            href="#"
+            href="#privacy-policy"
           >
             Privacy Policy
           </Link>
           <Link
             onClick={() => setIsTermsOfServiceOpen(true)}
             className="hover:underline hover:underline-offset-4"
-            href="#"
+            href="#terms-of-service"
           >
             Terms of Service
           </Link>
@@ -136,21 +136,21 @@ export function MobileFooter() {
         <Link
           onClick={() => setIsSupportOpen(true)}
           className="hover:underline hover:underline-offset-4"
-          href="#"
+          href="#support"
         >
           Support
         </Link>
         <Link
           onClick={() => setIsPrivacyPolicyOpen(true)}
           className="hover:underline hover:underline-offset-4"
-          href="#"
+          href="#privacy-policy"
         >
           Privacy Policy
         </Link>
         <Link
           onClick={() => setIsTermsOfServiceOpen(true)}
           className="hover:underline hover:underline-offset-4"
-          href="#"
+          href="#terms-of-service"
         >
           Terms of Service
         </Link>

--- a/frontend/src/store/useStore.ts
+++ b/frontend/src/store/useStore.ts
@@ -33,7 +33,7 @@ interface AppState {
     setIsSupportOpen: (open: boolean) => void
 }
 
-export const useStore = create<AppState>((set) => ({
+export const useStore = create<AppState>((set, get) => ({
     // Initial state
     isAuthenticated: false,
     user: null,
@@ -48,9 +48,38 @@ export const useStore = create<AppState>((set) => ({
     setUser: (user) => set({ user }),
     setLoading: (loading) => set({ isLoading: loading }),
     logout: () => set({ isAuthenticated: false, user: null }),
-    setAuthDialogOpen: (open) => set({ isAuthDialogOpen: open }),
-    setIsLogin: (isLogin) => set({ isLogin }),
-    setIsPrivacyPolicyOpen: (open) => set({ isPrivacyPolicyOpen: open }),
-    setIsTermsOfServiceOpen: (open) => set({ isTermsOfServiceOpen: open }),
-    setIsSupportOpen: (open) => set({ isSupportOpen: open }),
+    setAuthDialogOpen: (open) => {
+        set({ isAuthDialogOpen: open });
+        if (open) {
+            // Set hash based on current login state
+            const hash = get().isLogin ? "#login" : "#signup";
+            window.history.pushState({}, "", window.location.pathname + hash);
+        }
+    },
+    setIsLogin: (isLogin) => {
+        set({ isLogin });
+        // Update hash if auth dialog is open
+        if (get().isAuthDialogOpen) {
+            const hash = isLogin ? "#login" : "#signup";
+            window.history.pushState({}, "", window.location.pathname + hash);
+        }
+    },
+    setIsPrivacyPolicyOpen: (open) => {
+        set({ isPrivacyPolicyOpen: open });
+        if (open) {
+            window.history.pushState({}, "", window.location.pathname + "#privacy-policy");
+        }
+    },
+    setIsTermsOfServiceOpen: (open) => {
+        set({ isTermsOfServiceOpen: open });
+        if (open) {
+            window.history.pushState({}, "", window.location.pathname + "#terms-of-service");
+        }
+    },
+    setIsSupportOpen: (open) => {
+        set({ isSupportOpen: open });
+        if (open) {
+            window.history.pushState({}, "", window.location.pathname + "#support");
+        }
+    },
 }))

--- a/frontend/src/utils/useHashModalRouting.ts
+++ b/frontend/src/utils/useHashModalRouting.ts
@@ -1,0 +1,82 @@
+import { useStore } from "@/store/useStore";
+import { useEffect } from "react";
+
+/**
+ * Custom hook for handling hash-based modal routing
+ * Opens modals based on URL hash and clears hash when modals are closed
+ */
+export function useHashModalRouting() {
+    const {
+        isSupportOpen,
+        isPrivacyPolicyOpen,
+        isTermsOfServiceOpen,
+        isAuthDialogOpen,
+
+        setIsSupportOpen,
+        setIsPrivacyPolicyOpen,
+        setIsTermsOfServiceOpen,
+        setAuthDialogOpen,
+        setIsLogin,
+    } = useStore();
+
+    // Handle hash-based routing for modals
+    useEffect(() => {
+        const handleHashChange = () => {
+            const hash = window.location.hash;
+
+            switch (hash) {
+                case "#support":
+                    setIsSupportOpen(true);
+                    break;
+                case "#privacy-policy":
+                    setIsPrivacyPolicyOpen(true);
+                    break;
+                case "#terms-of-service":
+                    setIsTermsOfServiceOpen(true);
+                    break;
+                case "#login":
+                    setAuthDialogOpen(true);
+                    setIsLogin(true);
+                    break;
+                case "#signup":
+                    setAuthDialogOpen(true);
+                    setIsLogin(false);
+                    break;
+                default:
+                    // Close all modals if no matching hash
+                    setIsSupportOpen(false);
+                    setIsPrivacyPolicyOpen(false);
+                    setIsTermsOfServiceOpen(false);
+                    setAuthDialogOpen(false);
+                    break;
+            }
+        };
+
+        // Check hash on initial load
+        handleHashChange();
+
+        // Listen for hash changes
+        window.addEventListener("hashchange", handleHashChange);
+
+        // Cleanup
+        return () => {
+            window.removeEventListener("hashchange", handleHashChange);
+        };
+    }, [setIsSupportOpen, setIsPrivacyPolicyOpen, setIsTermsOfServiceOpen, setAuthDialogOpen, setIsLogin]);
+
+    // Clear hash when modals are closed
+    useEffect(() => {
+        const currentHash = window.location.hash;
+
+        // If there's a hash but no modal is open, clear the hash
+        if (
+            currentHash &&
+            !isSupportOpen &&
+            !isPrivacyPolicyOpen &&
+            !isTermsOfServiceOpen &&
+            !isAuthDialogOpen
+        ) {
+            window.history.replaceState({}, document.title, window.location.pathname);
+        }
+    }, [isSupportOpen, isPrivacyPolicyOpen, isTermsOfServiceOpen, isAuthDialogOpen]);
+}


### PR DESCRIPTION
**Summary**
- The hook allows you to navigate to the modal based on the hash in the URL
- It also clears the hash when the modal is closed
- Makes that forms and modals can be accessed via the URL

## Summary by Sourcery

Enable modal state synchronization with the URL by adding hash-based routing hook, updating store actions to push hashes, and adjusting footer links to trigger modals via URL fragments

New Features:
- Introduce useHashModalRouting hook to open and close modals based on URL hash and clear hash when modals are closed
- Integrate hash-based modal routing in the LandingPage component

Enhancements:
- Extend store actions to push corresponding URL hash when opening authentication, privacy policy, terms of service, and support modals
- Update Footer and MobileFooter links to use specific hash fragments for modal triggers